### PR TITLE
events API 응답 DTO 수정

### DIFF
--- a/src/main/java/ddip/me/ddipbe/presentation/dto/request/CreateEventReq.java
+++ b/src/main/java/ddip/me/ddipbe/presentation/dto/request/CreateEventReq.java
@@ -1,17 +1,23 @@
 package ddip.me.ddipbe.presentation.dto.request;
 
-import lombok.AllArgsConstructor;
 import lombok.Getter;
 
 import java.time.LocalDateTime;
 
 @Getter
-@AllArgsConstructor
 public class CreateEventReq {
 
-    private String title;
-    private Integer permitCount;
-    private String content;
-    private LocalDateTime start;
-    private LocalDateTime end;
+    private final String title;
+    private final Integer permitCount;
+    private final String content;
+    private final LocalDateTime start;
+    private final LocalDateTime end;
+
+    public CreateEventReq(String title, Integer permitCount, String content, LocalDateTime start, LocalDateTime end) {
+        this.title = title;
+        this.permitCount = permitCount;
+        this.content = content;
+        this.start = start;
+        this.end = end;
+    }
 }

--- a/src/main/java/ddip/me/ddipbe/presentation/dto/request/SigninReq.java
+++ b/src/main/java/ddip/me/ddipbe/presentation/dto/request/SigninReq.java
@@ -1,10 +1,15 @@
 package ddip.me.ddipbe.presentation.dto.request;
 
-import lombok.Data;
+import lombok.Getter;
 
-@Data
+@Getter
 public class SigninReq {
 
-    private String email;
-    private String password;
+    private final String email;
+    private final String password;
+
+    public SigninReq(String email, String password) {
+        this.email = email;
+        this.password = password;
+    }
 }

--- a/src/main/java/ddip/me/ddipbe/presentation/dto/request/SignupReq.java
+++ b/src/main/java/ddip/me/ddipbe/presentation/dto/request/SignupReq.java
@@ -1,10 +1,15 @@
 package ddip.me.ddipbe.presentation.dto.request;
 
-import lombok.Data;
+import lombok.Getter;
 
-@Data
+@Getter
 public class SignupReq {
 
-    private String email;
-    private String password;
+    private final String email;
+    private final String password;
+
+    public SignupReq(String email, String password) {
+        this.email = email;
+        this.password = password;
+    }
 }

--- a/src/main/java/ddip/me/ddipbe/presentation/dto/response/EventDetailRes.java
+++ b/src/main/java/ddip/me/ddipbe/presentation/dto/response/EventDetailRes.java
@@ -5,17 +5,20 @@ import ddip.me.ddipbe.domain.Event;
 import lombok.Getter;
 
 import java.time.LocalDateTime;
+import java.util.UUID;
 
 @Getter
 public class EventDetailRes {
-    private String title;
-    private Integer permitCount;
-    private LocalDateTime start;
-    private LocalDateTime end;
-    private Long memberId;
+    private final String title;
+    private final UUID uuid;
+    private final Integer permitCount;
+    private final LocalDateTime start;
+    private final LocalDateTime end;
+    private final Long memberId;
 
     public EventDetailRes(Event event) {
         this.title = event.getTitle();
+        this.uuid = event.getUuid();
         this.permitCount = event.getPermitCount();
         this.start = event.getStart();
         this.end = event.getEnd();

--- a/src/main/java/ddip/me/ddipbe/presentation/dto/response/EventOwnRes.java
+++ b/src/main/java/ddip/me/ddipbe/presentation/dto/response/EventOwnRes.java
@@ -4,20 +4,23 @@ import ddip.me.ddipbe.domain.Event;
 import lombok.Getter;
 
 import java.time.LocalDateTime;
+import java.util.UUID;
 
 import static java.time.LocalDateTime.now;
 
 @Getter
 public class EventOwnRes {
-    private String title;
-    private Integer permitCount;
-    private String contents;
-    private LocalDateTime start;
-    private LocalDateTime end;
-    private boolean isOpen;
+    private final String title;
+    private final UUID uuid;
+    private final Integer permitCount;
+    private final String contents;
+    private final LocalDateTime end;
+    private final LocalDateTime start;
+    private final boolean isOpen;
 
     public EventOwnRes(Event event) {
         this.title = event.getTitle();
+        this.uuid = event.getUuid();
         this.permitCount = event.getPermitCount();
         this.contents = event.getContent();
         this.start = event.getStart();

--- a/src/main/java/ddip/me/ddipbe/presentation/dto/response/EventUUIDRes.java
+++ b/src/main/java/ddip/me/ddipbe/presentation/dto/response/EventUUIDRes.java
@@ -7,9 +7,9 @@ import java.util.UUID;
 @Getter
 public class EventUUIDRes {
 
-    private UUID eventUuid;
+    private final UUID eventUuid;
 
-    public EventUUIDRes(UUID eventUuid) {
-        this.eventUuid = eventUuid;
+    public EventUUIDRes(UUID uuid) {
+        this.eventUuid = uuid;
     }
 }

--- a/src/main/java/ddip/me/ddipbe/presentation/dto/response/MemberIdRes.java
+++ b/src/main/java/ddip/me/ddipbe/presentation/dto/response/MemberIdRes.java
@@ -1,11 +1,13 @@
 package ddip.me.ddipbe.presentation.dto.response;
 
-import lombok.AllArgsConstructor;
-import lombok.Data;
+import lombok.Getter;
 
-@Data
-@AllArgsConstructor
+@Getter
 public class MemberIdRes {
 
-    private long memberId;
+    private final long memberId;
+
+    public MemberIdRes(long memberId) {
+        this.memberId = memberId;
+    }
 }

--- a/src/main/java/ddip/me/ddipbe/presentation/dto/response/MemberMeRes.java
+++ b/src/main/java/ddip/me/ddipbe/presentation/dto/response/MemberMeRes.java
@@ -1,12 +1,15 @@
 package ddip.me.ddipbe.presentation.dto.response;
 
-import lombok.AllArgsConstructor;
-import lombok.Data;
+import lombok.Getter;
 
-@Data
-@AllArgsConstructor
+@Getter
 public class MemberMeRes {
 
-    private long id;
-    private String email;
+    private final long id;
+    private final String email;
+
+    public MemberMeRes(long id, String email) {
+        this.id = id;
+        this.email = email;
+    }
 }


### PR DESCRIPTION
## 상세 내용

- events API 응답에 UUID 필드 추가
- 모든 request, response DTO 필드 final 처리

## 비고

- IntelliJ에서 build 설정을 Gradle이 아니라 IntelliJ로 할 경우 deserialization에서 에러가 납니다. Gradle로 유지해주세요.

    ![스크린샷 2023-11-07 오후 5 48 33](https://github.com/ddip-team/ddip-be/assets/25472942/c3cab14c-c7a4-45f2-a672-69671d689149)

    ```
    com.fasterxml.jackson.databind.exc.InvalidDefinitionException: Cannot construct instance of 
    `ddip.me.ddipbe.presentation.dto.request.SigninReq` (no Creators, like default constructor, exist): cannot deserialize 
    from Object value (no delegate- or property-based Creator)
    ```