### PR TITLE
사용자용 events v1 API 구현

### DIFF
--- a/src/main/java/ddip/me/ddipbe/application/EventService.java
+++ b/src/main/java/ddip/me/ddipbe/application/EventService.java
@@ -16,10 +16,10 @@ import java.time.LocalDateTime;
 import java.util.List;
 import java.util.UUID;
 
-@Service
-@Transactional(readOnly = true)
-@RequiredArgsConstructor
 @Log4j2
+@Transactional(readOnly = true)
+@Service
+@RequiredArgsConstructor
 public class EventService {
 
     private final EventRepository eventRepository;
@@ -28,7 +28,7 @@ public class EventService {
     private final MemberRepository memberRepository; // TODO - MemberServiceLayer에서 호출로 추후 리팩터링
 
     @Transactional
-    public UUID createEvent(String title, Integer permitCount, String content, LocalDateTime start, LocalDateTime end, Long memberId) {
+    public Event createEvent(String title, Integer permitCount, String content, LocalDateTime start, LocalDateTime end, Long memberId) {
         Member findMember = memberRepository.findById(memberId)
                 .orElseThrow(() -> new EventNotFoundException("ID가 존재하지 않습니다"));
 
@@ -47,7 +47,7 @@ public class EventService {
         );
         event = eventRepository.save(event);
 
-        return event.getUuid();
+        return event;
     }
 
     public Event findEventByUuid(UUID uuid) {

--- a/src/main/java/ddip/me/ddipbe/application/MemberService.java
+++ b/src/main/java/ddip/me/ddipbe/application/MemberService.java
@@ -8,7 +8,9 @@ import ddip.me.ddipbe.domain.repository.MemberRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
+@Transactional(readOnly = true)
 @Service
 @RequiredArgsConstructor
 public class MemberService {
@@ -20,7 +22,8 @@ public class MemberService {
         return memberRepository.findById(memberId).orElseThrow(MemberNotFoundException::new);
     }
 
-    public long signup(String email, String password) {
+    @Transactional
+    public Member signup(String email, String password) {
         if (memberRepository.existsByEmail(email)) {
             throw new AlreadySignedUpException();
         }
@@ -28,7 +31,7 @@ public class MemberService {
         Member member = new Member(email, passwordEncoder.encode(password));
         member = memberRepository.save(member);
 
-        return member.getId();
+        return member;
     }
 
     public long signin(String email, String password) {

--- a/src/main/java/ddip/me/ddipbe/application/exception/EventAlreadyAppliedException.java
+++ b/src/main/java/ddip/me/ddipbe/application/exception/EventAlreadyAppliedException.java
@@ -1,0 +1,7 @@
+package ddip.me.ddipbe.application.exception;
+
+public class EventAlreadyAppliedException extends RuntimeException {
+    public EventAlreadyAppliedException() {
+        super("이미 신청한 이벤트입니다.");
+    }
+}

--- a/src/main/java/ddip/me/ddipbe/application/exception/EventCapacityFullException.java
+++ b/src/main/java/ddip/me/ddipbe/application/exception/EventCapacityFullException.java
@@ -1,0 +1,7 @@
+package ddip.me.ddipbe.application.exception;
+
+public class EventCapacityFullException extends RuntimeException {
+    public EventCapacityFullException() {
+        super("이벤트 정원이 가득 찼습니다.");
+    }
+}

--- a/src/main/java/ddip/me/ddipbe/application/exception/EventNotOpenException.java
+++ b/src/main/java/ddip/me/ddipbe/application/exception/EventNotOpenException.java
@@ -1,0 +1,7 @@
+package ddip.me.ddipbe.application.exception;
+
+public class EventNotOpenException extends RuntimeException {
+    public EventNotOpenException() {
+        super("이벤트 기간이 아닙니다.");
+    }
+}

--- a/src/main/java/ddip/me/ddipbe/application/exception/PermitNotFoundException.java
+++ b/src/main/java/ddip/me/ddipbe/application/exception/PermitNotFoundException.java
@@ -1,0 +1,7 @@
+package ddip.me.ddipbe.application.exception;
+
+public class PermitNotFoundException extends RuntimeException {
+    public PermitNotFoundException() {
+        super("이벤트 성공 기록이 존재하지 않습니다.");
+    }
+}

--- a/src/main/java/ddip/me/ddipbe/domain/Event.java
+++ b/src/main/java/ddip/me/ddipbe/domain/Event.java
@@ -7,6 +7,7 @@ import lombok.Getter;
 import lombok.NoArgsConstructor;
 
 import java.time.LocalDateTime;
+import java.util.ArrayList;
 import java.util.List;
 import java.util.UUID;
 
@@ -26,14 +27,16 @@ public class Event {
 
     private Integer permitCount;
 
+    private Integer remainCount;
+
     private String content;
 
     private LocalDateTime start;
 
     private LocalDateTime end;
 
-    @OneToMany(mappedBy = "event", orphanRemoval = true, cascade = CascadeType.ALL)
-    private List<Permit> permits;
+    @OneToMany(mappedBy = "event", cascade = CascadeType.PERSIST)
+    private List<Permit> permits = new ArrayList<>();
 
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "member_id")
@@ -43,9 +46,26 @@ public class Event {
         this.uuid = uuid;
         this.title = title;
         this.permitCount = permitCount;
+        this.remainCount = permitCount;
         this.content = content;
         this.start = start;
         this.end = end;
         this.member = member;
+    }
+
+    public boolean isOpen(LocalDateTime now) {
+        return start.isBefore(now) && end.isAfter(now);
+    }
+
+    public boolean decreaseRemainCount() {
+        if (remainCount == 0) {
+            return false;
+        }
+        remainCount--;
+        return true;
+    }
+
+    public void addPermit(Permit permit) {
+        permits.add(permit);
     }
 }

--- a/src/main/java/ddip/me/ddipbe/domain/Member.java
+++ b/src/main/java/ddip/me/ddipbe/domain/Member.java
@@ -12,6 +12,7 @@ import java.util.List;
 @Entity
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
 public class Member {
 
     @Id

--- a/src/main/java/ddip/me/ddipbe/domain/Permit.java
+++ b/src/main/java/ddip/me/ddipbe/domain/Permit.java
@@ -2,12 +2,14 @@ package ddip.me.ddipbe.domain;
 
 import jakarta.persistence.*;
 import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
 @Entity
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
 public class Permit {
 
     @Id
@@ -16,7 +18,7 @@ public class Permit {
 
     private String token;
 
-    @ManyToOne(fetch = FetchType.LAZY)
+    @ManyToOne(fetch = FetchType.LAZY, optional = false)
     @JoinColumn(name = "event_id")
     private Event event;
 

--- a/src/main/java/ddip/me/ddipbe/domain/Permit.java
+++ b/src/main/java/ddip/me/ddipbe/domain/Permit.java
@@ -2,14 +2,12 @@ package ddip.me.ddipbe.domain;
 
 import jakarta.persistence.*;
 import lombok.AccessLevel;
-import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
 @Entity
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
-@AllArgsConstructor
 public class Permit {
 
     @Id
@@ -21,4 +19,9 @@ public class Permit {
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "event_id")
     private Event event;
+
+    public Permit(String token, Event event) {
+        this.token = token;
+        this.event = event;
+    }
 }

--- a/src/main/java/ddip/me/ddipbe/domain/repository/EventRepository.java
+++ b/src/main/java/ddip/me/ddipbe/domain/repository/EventRepository.java
@@ -2,7 +2,10 @@ package ddip.me.ddipbe.domain.repository;
 
 import ddip.me.ddipbe.domain.Event;
 import ddip.me.ddipbe.domain.Member;
+import jakarta.persistence.LockModeType;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Lock;
+import org.springframework.data.jpa.repository.Query;
 
 import java.time.LocalDateTime;
 import java.util.List;
@@ -12,6 +15,10 @@ import java.util.UUID;
 public interface EventRepository extends JpaRepository<Event, Long> {
 
     Optional<Event> findByUuid(UUID uuid);
+
+    @Lock(LockModeType.PESSIMISTIC_WRITE)
+    @Query("select e from Event e where e.uuid = :uuid")
+    Optional<Event> findByUuidForUpdate(UUID uuid);
 
     List<Event> findAllByMember(Member member);
 

--- a/src/main/java/ddip/me/ddipbe/domain/repository/PermitRepository.java
+++ b/src/main/java/ddip/me/ddipbe/domain/repository/PermitRepository.java
@@ -1,0 +1,15 @@
+package ddip.me.ddipbe.domain.repository;
+
+import ddip.me.ddipbe.domain.Permit;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+
+import java.util.Optional;
+import java.util.UUID;
+
+public interface PermitRepository extends JpaRepository<Permit, Long> {
+    @Query("SELECT p FROM Permit p JOIN FETCH p.event WHERE p.event.uuid = :uuid AND p.token = :token")
+    Optional<Permit> findByEventUuidAndToken(UUID uuid, String token);  // TODO: 쿼리 최적화
+
+    boolean existsByEventUuidAndToken(UUID uuid, String token);
+}

--- a/src/main/java/ddip/me/ddipbe/global/dto/ResponseEnvelope.java
+++ b/src/main/java/ddip/me/ddipbe/global/dto/ResponseEnvelope.java
@@ -7,7 +7,7 @@ import org.springframework.http.HttpStatus;
 public class ResponseEnvelope<T> {
     private final String code;
     private final T data;
-    private String message;
+    private final String message;
 
     public ResponseEnvelope(T data) {
         this.code = null;
@@ -18,12 +18,6 @@ public class ResponseEnvelope<T> {
     public ResponseEnvelope(String code, T data) {
         this.code = code;
         this.data = data;
-        this.message = null;
-    }
-
-    public ResponseEnvelope(String code) {
-        this.code = code;
-        this.data = null;
         this.message = null;
     }
 

--- a/src/main/java/ddip/me/ddipbe/presentation/EventController.java
+++ b/src/main/java/ddip/me/ddipbe/presentation/EventController.java
@@ -7,6 +7,7 @@ import ddip.me.ddipbe.global.dto.ResponseEnvelope;
 import ddip.me.ddipbe.presentation.dto.request.CreateEventReq;
 import ddip.me.ddipbe.presentation.dto.response.EventDetailRes;
 import ddip.me.ddipbe.presentation.dto.response.EventOwnRes;
+import ddip.me.ddipbe.presentation.dto.response.EventRes;
 import ddip.me.ddipbe.presentation.dto.response.EventUUIDRes;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.log4j.Log4j2;
@@ -50,5 +51,17 @@ public class EventController {
         List<Event> ownEvents = eventService.findOwnEvent(memberId, checkOpen);
         List<EventOwnRes> ownEvnetList = ownEvents.stream().map(EventOwnRes::new).toList();
         return new ResponseEnvelope<>(ownEvnetList);
+    }
+
+    @PostMapping("/{uuid}/apply")
+    public ResponseEnvelope<?> applyEvent(@PathVariable UUID uuid, @RequestParam String token) {
+        eventService.applyEvent(uuid, token);
+        return new ResponseEnvelope<>(null);
+    }
+
+    @GetMapping("/{uuid}/success")
+    public ResponseEnvelope<EventRes> findSuccessEvent(@PathVariable UUID uuid, @RequestParam String token) {
+        Event event = eventService.findSuccessEvent(uuid, token);
+        return new ResponseEnvelope<>(new EventRes(event));
     }
 }

--- a/src/main/java/ddip/me/ddipbe/presentation/EventController.java
+++ b/src/main/java/ddip/me/ddipbe/presentation/EventController.java
@@ -26,14 +26,14 @@ public class EventController {
 
     @PostMapping
     public ResponseEnvelope<EventUUIDRes> createEvent(@RequestBody CreateEventReq createEventReq, @SessionMemberId Long memberId) {
-        UUID eventUuid = eventService.createEvent(
+        Event event = eventService.createEvent(
                 createEventReq.getTitle(),
                 createEventReq.getPermitCount(),
                 createEventReq.getContent(),
                 createEventReq.getStart(),
                 createEventReq.getEnd(),
                 memberId);
-        return new ResponseEnvelope<>(new EventUUIDRes(eventUuid));
+        return new ResponseEnvelope<>(new EventUUIDRes(event.getUuid()));
     }
 
     @GetMapping("/{uuid}")

--- a/src/main/java/ddip/me/ddipbe/presentation/dto/response/EventRes.java
+++ b/src/main/java/ddip/me/ddipbe/presentation/dto/response/EventRes.java
@@ -1,0 +1,29 @@
+package ddip.me.ddipbe.presentation.dto.response;
+
+import ddip.me.ddipbe.domain.Event;
+import lombok.Getter;
+
+import java.time.LocalDateTime;
+import java.util.UUID;
+
+@Getter
+public class EventRes {
+
+    private final UUID uuid;
+    private final String title;
+    private final Integer permitCount;
+    private final String content;
+    private final LocalDateTime start;
+    private final LocalDateTime end;
+    private final Long memberId;
+
+    public EventRes(Event event) {
+        this.uuid = event.getUuid();
+        this.title = event.getTitle();
+        this.permitCount = event.getPermitCount();
+        this.content = event.getContent();
+        this.start = event.getStart();
+        this.end = event.getEnd();
+        this.memberId = event.getMember().getId();
+    }
+}

--- a/src/test/java/ddip/me/ddipbe/application/EventServiceTest.java
+++ b/src/test/java/ddip/me/ddipbe/application/EventServiceTest.java
@@ -2,67 +2,71 @@ package ddip.me.ddipbe.application;
 
 import ddip.me.ddipbe.application.exception.EventDateInvalidException;
 import ddip.me.ddipbe.application.exception.EventNotFoundException;
-import ddip.me.ddipbe.presentation.dto.request.CreateEventReq;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.transaction.annotation.Transactional;
 
+import java.time.LocalDateTime;
 import java.util.UUID;
 
-import static java.time.LocalDateTime.now;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
-
+// TODO: 테스트 코드 리팩토링
+@Transactional
 @SpringBootTest
 public class EventServiceTest {
 
     @Autowired
     private EventService eventService;
 
+    @DisplayName("이벤트 생성 시 유요하지 않은 회원 ID 입력시 예외가 발생한다.")
     @Test
-    @DisplayName("이벤트 생성 시 유효하지 못한 회원 ID 입력 예외 테스트")
     void eventCreateByFormattingValueExcepted_InvalidMemberId() {
-        //given
-        Long memberId = 9999L;
+        // given
+        long memberId = 9999L;
+        LocalDateTime now = LocalDateTime.now();
 
-        //when
-        assertThatThrownBy(() -> {
-                    eventService.createEvent(initializingCreateDTO(), memberId);
-                }
+        // when, then
+        assertThatThrownBy(() -> eventService.createEvent(
+                "test",
+                1,
+                "test",
+                now.minusDays(1),
+                now.plusDays(1),
+                memberId)
         ).isInstanceOf(EventNotFoundException.class);
     }
 
+    @DisplayName("이벤트 조회 시 유효하지 않은 UUID 입력시 예외가 발생한다.")
     @Test
-    @DisplayName("이벤트 조회시 유효하지 않은 UUID값 예외 테스트")
     void findEventByInvalidUuid() {
-        //given
+        // given
         UUID targetUuid = UUID.randomUUID();
 
-        //when
+        // when, then
         assertThatThrownBy(() -> {
                     eventService.findEventByUuid(targetUuid);
                 }
         ).isInstanceOf(EventNotFoundException.class);
     }
 
+    @DisplayName("이벤트 생성 시 유효하지 않은 날짜 입력시 예외가 발생한다.")
     @Test
     void eventCreateByFormattingValueExcepted_InvalidDateTime() {
-        //given
+        // given
         Long memberId = 1L;
+        LocalDateTime now = LocalDateTime.now();
 
-        //when
-        assertThatThrownBy(() -> {
-                    eventService.createEvent(initializingPastDateCreateDTO(), memberId);
-                }
+        // when, then
+        assertThatThrownBy(() -> eventService.createEvent(
+                "test",
+                1,
+                "test",
+                now.minusDays(2),
+                now.minusDays(1),
+                memberId)
         ).isInstanceOf(EventDateInvalidException.class);
-    }
-
-    private CreateEventReq initializingCreateDTO() {
-        return new CreateEventReq("test", 1, "test", now().minusDays(1), now().plusDays(1));
-    }
-
-    private CreateEventReq initializingPastDateCreateDTO() {
-        return new CreateEventReq("test", 1, "test", now().minusDays(2), now().minusDays(1));
     }
 }


### PR DESCRIPTION
> Closes #15 

## 상세 내용

- 사용자용 events v1 API 구현
- 단순한 코드 리팩토링

## 비고

- 우선은 `LockModeType.PESSIMISTIC_WRITE`으로 비관적락을 사용한 동시성 처리를 했습니다. (부하 테스트 이후 쿼리 개선 예정)
- `EventServiceTest`의 코드에 몇 가지 문제점이 있지만 수정하지 않았습니다. (최적화 작업과 전반적인 리팩토링을 함께 진행하는게 좋아보임)