### PR TITLE
Entity 및 DTO 필드명 명시적으로 변경

### DIFF
--- a/src/main/java/ddip/me/ddipbe/application/EventService.java
+++ b/src/main/java/ddip/me/ddipbe/application/EventService.java
@@ -12,7 +12,7 @@ import lombok.extern.log4j.Log4j2;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
-import java.time.LocalDateTime;
+import java.time.ZonedDateTime;
 import java.util.List;
 import java.util.UUID;
 
@@ -28,7 +28,7 @@ public class EventService {
     private final MemberRepository memberRepository; // TODO - MemberServiceLayer에서 호출로 추후 리팩터링
 
     @Transactional
-    public Event createEvent(String title, Integer permitCount, String content, LocalDateTime start, LocalDateTime end, Long memberId) {
+    public Event createEvent(String title, Integer permitCount, String content, ZonedDateTime start, ZonedDateTime end, Long memberId) {
         Member findMember = memberRepository.findById(memberId)
                 .orElseThrow(() -> new EventNotFoundException("ID가 존재하지 않습니다"));
 
@@ -58,14 +58,14 @@ public class EventService {
     public List<Event> findOwnEvent(Long memberId, boolean filterOpen) {
         Member foundMember = memberRepository.findById(memberId).orElseThrow(() -> new EventNotFoundException("ID가 존재하지 않습니다"));
         if (filterOpen) {
-            LocalDateTime now = LocalDateTime.now();
+            ZonedDateTime now = ZonedDateTime.now();
             return eventRepository.findAllByStartDateTimeBeforeAndEndDateTimeAfter(now, now);
         }
         return eventRepository.findAllByMember(foundMember);
     }
 
-    private boolean eventEndTimeIsValidValue(LocalDateTime start, LocalDateTime end) {
-        return end.isAfter(start) && end.isAfter(LocalDateTime.now());
+    private boolean eventEndTimeIsValidValue(ZonedDateTime start, ZonedDateTime end) {
+        return end.isAfter(start) && end.isAfter(ZonedDateTime.now());
     }
 
     @Transactional
@@ -73,7 +73,7 @@ public class EventService {
         Event event = eventRepository.findByUuidForUpdate(uuid)
                 .orElseThrow(() -> new EventNotFoundException("DB에서 UUID를 찾을 수 없습니다."));
 
-        LocalDateTime now = LocalDateTime.now();
+        ZonedDateTime now = ZonedDateTime.now();
         if (!event.isOpen(now)) {
             throw new EventNotOpenException();
         }

--- a/src/main/java/ddip/me/ddipbe/application/EventService.java
+++ b/src/main/java/ddip/me/ddipbe/application/EventService.java
@@ -3,7 +3,7 @@ package ddip.me.ddipbe.application;
 import ddip.me.ddipbe.application.exception.*;
 import ddip.me.ddipbe.domain.Event;
 import ddip.me.ddipbe.domain.Member;
-import ddip.me.ddipbe.domain.Permit;
+import ddip.me.ddipbe.domain.SuccessRecord;
 import ddip.me.ddipbe.domain.repository.EventRepository;
 import ddip.me.ddipbe.domain.repository.MemberRepository;
 import ddip.me.ddipbe.domain.repository.PermitRepository;
@@ -59,7 +59,7 @@ public class EventService {
         Member foundMember = memberRepository.findById(memberId).orElseThrow(() -> new EventNotFoundException("ID가 존재하지 않습니다"));
         if (filterOpen) {
             LocalDateTime now = LocalDateTime.now();
-            return eventRepository.findAllByStartBeforeAndEndAfter(now, now);
+            return eventRepository.findAllByStartDateTimeBeforeAndEndDateTimeAfter(now, now);
         }
         return eventRepository.findAllByMember(foundMember);
     }
@@ -87,11 +87,11 @@ public class EventService {
             throw new EventCapacityFullException();
         }
 
-        event.addPermit(new Permit(token, event));
+        event.addPermit(new SuccessRecord(token, event));
     }
 
     public Event findSuccessEvent(UUID uuid, String token) {
-        Permit permit = permitRepository.findByEventUuidAndToken(uuid, token).orElseThrow(PermitNotFoundException::new);
-        return permit.getEvent();
+        SuccessRecord successRecord = permitRepository.findByEventUuidAndToken(uuid, token).orElseThrow(PermitNotFoundException::new);
+        return successRecord.getEvent();
     }
 }

--- a/src/main/java/ddip/me/ddipbe/domain/Event.java
+++ b/src/main/java/ddip/me/ddipbe/domain/Event.java
@@ -25,36 +25,36 @@ public class Event {
 
     private String title;
 
-    private Integer permitCount;
+    private Integer limitCount;
 
     private Integer remainCount;
 
-    private String content;
+    private String successContent;
 
-    private LocalDateTime start;
+    private LocalDateTime startDateTime;
 
-    private LocalDateTime end;
+    private LocalDateTime endDateTime;
 
     @OneToMany(mappedBy = "event", cascade = CascadeType.PERSIST)
-    private List<Permit> permits = new ArrayList<>();
+    private List<SuccessRecord> successRecords = new ArrayList<>();
 
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "member_id")
     private Member member;
 
-    public Event(UUID uuid, String title, Integer permitCount, String content, LocalDateTime start, LocalDateTime end, Member member) {
+    public Event(UUID uuid, String title, Integer limitCount, String successContent, LocalDateTime startDateTime, LocalDateTime endDateTime, Member member) {
         this.uuid = uuid;
         this.title = title;
-        this.permitCount = permitCount;
-        this.remainCount = permitCount;
-        this.content = content;
-        this.start = start;
-        this.end = end;
+        this.limitCount = limitCount;
+        this.remainCount = limitCount;
+        this.successContent = successContent;
+        this.startDateTime = startDateTime;
+        this.endDateTime = endDateTime;
         this.member = member;
     }
 
     public boolean isOpen(LocalDateTime now) {
-        return start.isBefore(now) && end.isAfter(now);
+        return startDateTime.isBefore(now) && endDateTime.isAfter(now);
     }
 
     public boolean decreaseRemainCount() {
@@ -65,7 +65,7 @@ public class Event {
         return true;
     }
 
-    public void addPermit(Permit permit) {
-        permits.add(permit);
+    public void addPermit(SuccessRecord successRecord) {
+        successRecords.add(successRecord);
     }
 }

--- a/src/main/java/ddip/me/ddipbe/domain/Event.java
+++ b/src/main/java/ddip/me/ddipbe/domain/Event.java
@@ -6,7 +6,7 @@ import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
-import java.time.LocalDateTime;
+import java.time.ZonedDateTime;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.UUID;
@@ -31,9 +31,9 @@ public class Event {
 
     private String successContent;
 
-    private LocalDateTime startDateTime;
+    private ZonedDateTime startDateTime;
 
-    private LocalDateTime endDateTime;
+    private ZonedDateTime endDateTime;
 
     @OneToMany(mappedBy = "event", cascade = CascadeType.PERSIST)
     private List<SuccessRecord> successRecords = new ArrayList<>();
@@ -42,7 +42,7 @@ public class Event {
     @JoinColumn(name = "member_id")
     private Member member;
 
-    public Event(UUID uuid, String title, Integer limitCount, String successContent, LocalDateTime startDateTime, LocalDateTime endDateTime, Member member) {
+    public Event(UUID uuid, String title, Integer limitCount, String successContent, ZonedDateTime startDateTime, ZonedDateTime endDateTime, Member member) {
         this.uuid = uuid;
         this.title = title;
         this.limitCount = limitCount;
@@ -53,7 +53,7 @@ public class Event {
         this.member = member;
     }
 
-    public boolean isOpen(LocalDateTime now) {
+    public boolean isOpen(ZonedDateTime now) {
         return startDateTime.isBefore(now) && endDateTime.isAfter(now);
     }
 

--- a/src/main/java/ddip/me/ddipbe/domain/SuccessRecord.java
+++ b/src/main/java/ddip/me/ddipbe/domain/SuccessRecord.java
@@ -10,7 +10,7 @@ import lombok.NoArgsConstructor;
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @AllArgsConstructor
-public class Permit {
+public class SuccessRecord {
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
@@ -22,7 +22,7 @@ public class Permit {
     @JoinColumn(name = "event_id")
     private Event event;
 
-    public Permit(String token, Event event) {
+    public SuccessRecord(String token, Event event) {
         this.token = token;
         this.event = event;
     }

--- a/src/main/java/ddip/me/ddipbe/domain/repository/EventRepository.java
+++ b/src/main/java/ddip/me/ddipbe/domain/repository/EventRepository.java
@@ -22,5 +22,5 @@ public interface EventRepository extends JpaRepository<Event, Long> {
 
     List<Event> findAllByMember(Member member);
 
-    List<Event> findAllByStartBeforeAndEndAfter(LocalDateTime start, LocalDateTime end);
+    List<Event> findAllByStartDateTimeBeforeAndEndDateTimeAfter(LocalDateTime start, LocalDateTime end);
 }

--- a/src/main/java/ddip/me/ddipbe/domain/repository/EventRepository.java
+++ b/src/main/java/ddip/me/ddipbe/domain/repository/EventRepository.java
@@ -7,7 +7,7 @@ import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Lock;
 import org.springframework.data.jpa.repository.Query;
 
-import java.time.LocalDateTime;
+import java.time.ZonedDateTime;
 import java.util.List;
 import java.util.Optional;
 import java.util.UUID;
@@ -22,5 +22,5 @@ public interface EventRepository extends JpaRepository<Event, Long> {
 
     List<Event> findAllByMember(Member member);
 
-    List<Event> findAllByStartDateTimeBeforeAndEndDateTimeAfter(LocalDateTime start, LocalDateTime end);
+    List<Event> findAllByStartDateTimeBeforeAndEndDateTimeAfter(ZonedDateTime start, ZonedDateTime end);
 }

--- a/src/main/java/ddip/me/ddipbe/domain/repository/PermitRepository.java
+++ b/src/main/java/ddip/me/ddipbe/domain/repository/PermitRepository.java
@@ -1,15 +1,15 @@
 package ddip.me.ddipbe.domain.repository;
 
-import ddip.me.ddipbe.domain.Permit;
+import ddip.me.ddipbe.domain.SuccessRecord;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 
 import java.util.Optional;
 import java.util.UUID;
 
-public interface PermitRepository extends JpaRepository<Permit, Long> {
-    @Query("SELECT p FROM Permit p JOIN FETCH p.event WHERE p.event.uuid = :uuid AND p.token = :token")
-    Optional<Permit> findByEventUuidAndToken(UUID uuid, String token);  // TODO: 쿼리 최적화
+public interface PermitRepository extends JpaRepository<SuccessRecord, Long> {
+    @Query("SELECT p FROM SuccessRecord p JOIN FETCH p.event WHERE p.event.uuid = :uuid AND p.token = :token")
+    Optional<SuccessRecord> findByEventUuidAndToken(UUID uuid, String token);  // TODO: 쿼리 최적화
 
     boolean existsByEventUuidAndToken(UUID uuid, String token);
 }

--- a/src/main/java/ddip/me/ddipbe/presentation/EventController.java
+++ b/src/main/java/ddip/me/ddipbe/presentation/EventController.java
@@ -28,10 +28,10 @@ public class EventController {
     public ResponseEnvelope<EventUUIDRes> createEvent(@RequestBody CreateEventReq createEventReq, @SessionMemberId Long memberId) {
         Event event = eventService.createEvent(
                 createEventReq.getTitle(),
-                createEventReq.getPermitCount(),
-                createEventReq.getContent(),
-                createEventReq.getStart(),
-                createEventReq.getEnd(),
+                createEventReq.getLimitCount(),
+                createEventReq.getSuccessContent(),
+                createEventReq.getStartDateTime(),
+                createEventReq.getEndDateTime(),
                 memberId);
         return new ResponseEnvelope<>(new EventUUIDRes(event.getUuid()));
     }
@@ -44,10 +44,7 @@ public class EventController {
 
     @GetMapping("/me")
     public ResponseEnvelope<?> findOwnEvent(@SessionMemberId Long memberId, @RequestParam(required = false) String open) {
-        boolean checkOpen = false;
-        if (open != null) {
-            checkOpen = true;
-        }
+        boolean checkOpen = open != null;
         List<Event> ownEvents = eventService.findOwnEvent(memberId, checkOpen);
         List<EventOwnRes> ownEvnetList = ownEvents.stream().map(EventOwnRes::new).toList();
         return new ResponseEnvelope<>(ownEvnetList);

--- a/src/main/java/ddip/me/ddipbe/presentation/MemberController.java
+++ b/src/main/java/ddip/me/ddipbe/presentation/MemberController.java
@@ -32,9 +32,9 @@ public class MemberController {
     @ResponseStatus(HttpStatus.CREATED)
     @PostMapping("signup")
     public ResponseEnvelope<MemberIdRes> signup(@RequestBody SignupReq signupRequest) {
-        long signedUpMemberId = memberService.signup(signupRequest.getEmail(), signupRequest.getPassword());
+        Member member = memberService.signup(signupRequest.getEmail(), signupRequest.getPassword());
 
-        return new ResponseEnvelope<>(new MemberIdRes(signedUpMemberId));
+        return new ResponseEnvelope<>(new MemberIdRes(member.getId()));
     }
 
     @PostMapping("signin")

--- a/src/main/java/ddip/me/ddipbe/presentation/dto/request/CreateEventReq.java
+++ b/src/main/java/ddip/me/ddipbe/presentation/dto/request/CreateEventReq.java
@@ -2,7 +2,7 @@ package ddip.me.ddipbe.presentation.dto.request;
 
 import lombok.Getter;
 
-import java.time.LocalDateTime;
+import java.time.ZonedDateTime;
 
 @Getter
 public class CreateEventReq {
@@ -10,10 +10,10 @@ public class CreateEventReq {
     private final String title;
     private final Integer limitCount;
     private final String successContent;
-    private final LocalDateTime startDateTime;
-    private final LocalDateTime endDateTime;
+    private final ZonedDateTime startDateTime;
+    private final ZonedDateTime endDateTime;
 
-    public CreateEventReq(String title, Integer limitCount, String successContent, LocalDateTime startDateTime, LocalDateTime endDateTime) {
+    public CreateEventReq(String title, Integer limitCount, String successContent, ZonedDateTime startDateTime, ZonedDateTime endDateTime) {
         this.title = title;
         this.limitCount = limitCount;
         this.successContent = successContent;

--- a/src/main/java/ddip/me/ddipbe/presentation/dto/request/CreateEventReq.java
+++ b/src/main/java/ddip/me/ddipbe/presentation/dto/request/CreateEventReq.java
@@ -8,16 +8,16 @@ import java.time.LocalDateTime;
 public class CreateEventReq {
 
     private final String title;
-    private final Integer permitCount;
-    private final String content;
-    private final LocalDateTime start;
-    private final LocalDateTime end;
+    private final Integer limitCount;
+    private final String successContent;
+    private final LocalDateTime startDateTime;
+    private final LocalDateTime endDateTime;
 
-    public CreateEventReq(String title, Integer permitCount, String content, LocalDateTime start, LocalDateTime end) {
+    public CreateEventReq(String title, Integer limitCount, String successContent, LocalDateTime startDateTime, LocalDateTime endDateTime) {
         this.title = title;
-        this.permitCount = permitCount;
-        this.content = content;
-        this.start = start;
-        this.end = end;
+        this.limitCount = limitCount;
+        this.successContent = successContent;
+        this.startDateTime = startDateTime;
+        this.endDateTime = endDateTime;
     }
 }

--- a/src/main/java/ddip/me/ddipbe/presentation/dto/response/EventDetailRes.java
+++ b/src/main/java/ddip/me/ddipbe/presentation/dto/response/EventDetailRes.java
@@ -11,17 +11,17 @@ import java.util.UUID;
 public class EventDetailRes {
     private final String title;
     private final UUID uuid;
-    private final Integer permitCount;
-    private final LocalDateTime start;
-    private final LocalDateTime end;
+    private final Integer limitCount;
+    private final LocalDateTime startDateTime;
+    private final LocalDateTime endDateTime;
     private final Long memberId;
 
     public EventDetailRes(Event event) {
         this.title = event.getTitle();
         this.uuid = event.getUuid();
-        this.permitCount = event.getPermitCount();
-        this.start = event.getStart();
-        this.end = event.getEnd();
+        this.limitCount = event.getLimitCount();
+        this.startDateTime = event.getStartDateTime();
+        this.endDateTime = event.getEndDateTime();
         this.memberId = event.getMember().getId();
     }
 }

--- a/src/main/java/ddip/me/ddipbe/presentation/dto/response/EventDetailRes.java
+++ b/src/main/java/ddip/me/ddipbe/presentation/dto/response/EventDetailRes.java
@@ -4,7 +4,7 @@ package ddip.me.ddipbe.presentation.dto.response;
 import ddip.me.ddipbe.domain.Event;
 import lombok.Getter;
 
-import java.time.LocalDateTime;
+import java.time.ZonedDateTime;
 import java.util.UUID;
 
 @Getter
@@ -12,8 +12,8 @@ public class EventDetailRes {
     private final String title;
     private final UUID uuid;
     private final Integer limitCount;
-    private final LocalDateTime startDateTime;
-    private final LocalDateTime endDateTime;
+    private final ZonedDateTime startDateTime;
+    private final ZonedDateTime endDateTime;
     private final Long memberId;
 
     public EventDetailRes(Event event) {

--- a/src/main/java/ddip/me/ddipbe/presentation/dto/response/EventOwnRes.java
+++ b/src/main/java/ddip/me/ddipbe/presentation/dto/response/EventOwnRes.java
@@ -3,10 +3,10 @@ package ddip.me.ddipbe.presentation.dto.response;
 import ddip.me.ddipbe.domain.Event;
 import lombok.Getter;
 
-import java.time.LocalDateTime;
+import java.time.ZonedDateTime;
 import java.util.UUID;
 
-import static java.time.LocalDateTime.now;
+import static java.time.ZonedDateTime.now;
 
 @Getter
 public class EventOwnRes {
@@ -15,8 +15,8 @@ public class EventOwnRes {
     private final String title;
     private final Integer limitCount;
     private final String successContent;
-    private final LocalDateTime endDateTime;
-    private final LocalDateTime startDateTime;
+    private final ZonedDateTime endDateTime;
+    private final ZonedDateTime startDateTime;
     private final boolean isOpen;
 
     public EventOwnRes(Event event) {

--- a/src/main/java/ddip/me/ddipbe/presentation/dto/response/EventOwnRes.java
+++ b/src/main/java/ddip/me/ddipbe/presentation/dto/response/EventOwnRes.java
@@ -10,21 +10,22 @@ import static java.time.LocalDateTime.now;
 
 @Getter
 public class EventOwnRes {
-    private final String title;
+
     private final UUID uuid;
-    private final Integer permitCount;
-    private final String contents;
-    private final LocalDateTime end;
-    private final LocalDateTime start;
+    private final String title;
+    private final Integer limitCount;
+    private final String successContent;
+    private final LocalDateTime endDateTime;
+    private final LocalDateTime startDateTime;
     private final boolean isOpen;
 
     public EventOwnRes(Event event) {
         this.title = event.getTitle();
         this.uuid = event.getUuid();
-        this.permitCount = event.getPermitCount();
-        this.contents = event.getContent();
-        this.start = event.getStart();
-        this.end = event.getEnd();
-        this.isOpen = event.getStart().isBefore(now()) && event.getEnd().isAfter(now());
+        this.limitCount = event.getLimitCount();
+        this.successContent = event.getSuccessContent();
+        this.startDateTime = event.getStartDateTime();
+        this.endDateTime = event.getEndDateTime();
+        this.isOpen = event.getStartDateTime().isBefore(now()) && event.getEndDateTime().isAfter(now());
     }
 }

--- a/src/main/java/ddip/me/ddipbe/presentation/dto/response/EventRes.java
+++ b/src/main/java/ddip/me/ddipbe/presentation/dto/response/EventRes.java
@@ -3,7 +3,7 @@ package ddip.me.ddipbe.presentation.dto.response;
 import ddip.me.ddipbe.domain.Event;
 import lombok.Getter;
 
-import java.time.LocalDateTime;
+import java.time.ZonedDateTime;
 import java.util.UUID;
 
 @Getter
@@ -13,8 +13,8 @@ public class EventRes {
     private final String title;
     private final Integer limitCount;
     private final String successContent;
-    private final LocalDateTime startDateTime;
-    private final LocalDateTime endDateTime;
+    private final ZonedDateTime startDateTime;
+    private final ZonedDateTime endDateTime;
     private final Long memberId;
 
     public EventRes(Event event) {

--- a/src/main/java/ddip/me/ddipbe/presentation/dto/response/EventRes.java
+++ b/src/main/java/ddip/me/ddipbe/presentation/dto/response/EventRes.java
@@ -11,19 +11,19 @@ public class EventRes {
 
     private final UUID uuid;
     private final String title;
-    private final Integer permitCount;
-    private final String content;
-    private final LocalDateTime start;
-    private final LocalDateTime end;
+    private final Integer limitCount;
+    private final String successContent;
+    private final LocalDateTime startDateTime;
+    private final LocalDateTime endDateTime;
     private final Long memberId;
 
     public EventRes(Event event) {
         this.uuid = event.getUuid();
         this.title = event.getTitle();
-        this.permitCount = event.getPermitCount();
-        this.content = event.getContent();
-        this.start = event.getStart();
-        this.end = event.getEnd();
+        this.limitCount = event.getLimitCount();
+        this.successContent = event.getSuccessContent();
+        this.startDateTime = event.getStartDateTime();
+        this.endDateTime = event.getEndDateTime();
         this.memberId = event.getMember().getId();
     }
 }

--- a/src/test/java/ddip/me/ddipbe/application/EventServiceTest.java
+++ b/src/test/java/ddip/me/ddipbe/application/EventServiceTest.java
@@ -8,7 +8,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.transaction.annotation.Transactional;
 
-import java.time.LocalDateTime;
+import java.time.ZonedDateTime;
 import java.util.UUID;
 
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
@@ -26,7 +26,7 @@ public class EventServiceTest {
     void eventCreateByFormattingValueExcepted_InvalidMemberId() {
         // given
         long memberId = 9999L;
-        LocalDateTime now = LocalDateTime.now();
+        ZonedDateTime now = ZonedDateTime.now();
 
         // when, then
         assertThatThrownBy(() -> eventService.createEvent(
@@ -57,7 +57,7 @@ public class EventServiceTest {
     void eventCreateByFormattingValueExcepted_InvalidDateTime() {
         // given
         Long memberId = 1L;
-        LocalDateTime now = LocalDateTime.now();
+        ZonedDateTime now = ZonedDateTime.now();
 
         // when, then
         assertThatThrownBy(() -> eventService.createEvent(


### PR DESCRIPTION
> Closes #19, #18

## 상세 내용

- `LocalDateTime` 타입 변수 postfix 추가
- `Event.content` -> `Event.successContent`
- `Event.permitCount` -> `Event.limitCount`
- `Permit` -> `SuccessRecord`
- `LocalDateTime` -> `ZonedDateTime`

## 비고

- 요청에서 `ZonedDateTime` 에 대한 UTC만 입력되도록 하는 것은 일괄된 Validation 처리에서 적용할 예정